### PR TITLE
Fix display for Linux

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,13 +1,17 @@
 <!DOCTYPE html>
 <html>
 <style>
-body {background-color: black;}
-body {color: white;}
+body {
+	color: white;
+	background-color: black;
+	font-family: courier, monospace;
+	line-height: 85%;
+}
 </style>
 <body>
 <table>
 <tr>
-	<td valign="top"><p id="mapText" style="font-family:courier; line-height: 85%;"></p></td>
+	<td valign="top"><p id="mapText"></p></td>
 	<td valign="top"><p id="alerts"></p></td>
 </tr>
 <tr>


### PR DESCRIPTION
![broken_tower](https://user-images.githubusercontent.com/11293143/91539678-f8739500-e919-11ea-868f-497a46e045ad.png)

Firefox on Linux removes multiple spaces in a row, even for non-breaking 
spaces, resulting in a garbled map. Switch to monospace font to fix 
that.